### PR TITLE
CI: сборка с тестами, кеш Docker-слоёв, починка версии в образе

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Контекст сборки — весь репозиторий, но Dockerfile берёт из него только
+# .git, файлы сборки Gradle и src/, а Dockerfile.migrator — liquibase/.
+# Всё остальное исключаем, чтобы не гонять десятки мегабайт в билдер.
+#
+# ВНИМАНИЕ: .git исключать нельзя — Dockerfile копирует его внутрь,
+# плагин com.palantir.git-version определяет по нему версию сборки.
+
+# Результаты сборки
+/build/
+.gradle/
+*.war
+*.ear
+*.class
+
+# Документация и картинки
+/docs/
+/markdown_en/
+/markdown_ru/
+screenshot.png
+*.md
+
+# Инфраструктура, не участвующая в сборке образа
+/k8s/
+docker-compose.yml
+.env
+
+# IDE
+.idea/
+*.iml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Новый пуш в ту же ветку отменяет предыдущий незавершённый прогон
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Gradle build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # com.palantir.git-version определяет version по тегам,
+          # при shallow clone теги недоступны и версия получается неверной
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Print version
+        run: ./gradlew --no-daemon printVersion
+
+      - name: Build (compile + test + war)
+        run: ./gradlew --no-daemon --stacktrace build
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            build/reports/tests/test
+            build/test-results/test
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload WAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: TrackStudio-war
+          path: build/libs/TrackStudio.war
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,14 +5,40 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-
   build:
-
+    name: Docker build
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag trackstudio/app:$(date +%s)
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Dockerfile копирует .git внутрь сборки, а com.palantir.git-version
+          # определяет version по тегам. При shallow clone тегов нет и в образ
+          # попадает версия-заглушка вместо реальной.
+          fetch-depth: 0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: false
+          tags: trackstudio/app:${{ github.sha }}
+          # Кеш слоёв между прогонами: без него Gradle качает зависимости заново
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ target
 .bat
 .sh
 
+# Gradle
+/build/
+.gradle/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 


### PR DESCRIPTION
## Что было

В репозитории два workflow: `Docker Image CI` (собирает образ) и `CodeQL Advanced`. Оба зелёные. Чего не было — **сборки проекта как таковой**: `Dockerfile` собирает WAR командой `gradle clean war -x test`, то есть тесты не запускались нигде и никогда.

## Что добавлено

### Build (`.github/workflows/build.yml`)

`./gradlew build` на JDK 21 (temurin) с кешем Gradle через `gradle/actions/setup-gradle`. Отчёты тестов и `TrackStudio.war` выкладываются артефактами прогона, отдельный шаг `printVersion` показывает версию сборки в логе.

### Починена версия сборки в Docker-образе

Плагин `com.palantir.git-version` определяет `version` по git-тегам, а `actions/checkout` по умолчанию делает shallow clone **без тегов**. `Dockerfile` копирует `.git` внутрь сборки — значит, `version.properties` и имя артефакта в образе получали версию-заглушку.

Проверено локально на этом репозитории:

```
shallow clone (как сейчас в CI):  trackstudio.version=a3e8436
full history + tags:              trackstudio.version=v6.0.0-55-ga3e8436
```

Обоим workflow добавлен `fetch-depth: 0`.

### Docker Image CI

- Сборка переведена на `docker/build-push-action` с кешем слоёв `type=gha`. Без него Gradle на каждом прогоне заново качает все зависимости — отсюда стабильные 1м15с–1м26с на каждый пуш, включая пуши, которые правят только README.
- Тег образа `github.sha` вместо `$(date +%s)` — прогон теперь сопоставим с коммитом.
- Добавлен `.dockerignore`. Контекст сборки — весь репозиторий (27 МБ с картинками и markdown), притом `Dockerfile` берёт из него только `.git`, три файла Gradle и `src/`, а `Dockerfile.migrator` — только `liquibase/`. `.git` в исключения намеренно не попал: он нужен для версионирования.

### Обоим workflow

`concurrency` с `cancel-in-progress` (новый пуш в ветку отменяет предыдущий незавершённый прогон), явный `permissions: contents: read`, `workflow_dispatch` для ручного запуска.

### `.gitignore`

Добавлены `/build/` и `.gradle/` — файл остался с времён Maven и знал только про `target/`.

## Важно: тестов в проекте фактически нет

Шаг `test` в новом workflow сейчас **проходит вхолостую**. Все три тест-класса помечены `@Ignore`:

```
tests="1" skipped="1"   SliderTest
tests="1" skipped="1"   IndexManagerTest
tests="1" skipped="1"   SecuredTaskAdapterManagerTest
```

Снимать `@Ignore` в этом PR я не стал — это решение про код, а не про CI. Что выяснилось при проверке:

- **`IndexManagerTest`** — должен остаться отключённым: он создаёт список из 100 000 000 Lucene-документов в памяти, на раннере это гарантированный OOM.
- **`SecuredTaskAdapterManagerTest`** — требует поднятого `AdapterManager` и базы, в отрыве от приложения не работает.
- **`SliderTest`** — единственный, который реально можно включить: я снял `@Ignore` локально, тест прошёл (`tests="1" skipped="0" failures="0"`). Но включать его как есть смысла мало: у него нет ни одного assert-а, он только печатает результат, а внутри при этом гасится `GranException: I18n must be initialized before use` — то есть проходит он по деградировавшему пути. Тест возвращён в исходное состояние.

Пока в проекте не появятся настоящие тесты, ценность нового workflow — в том, что он компилирует весь Java-код и собирает WAR на каждый PR, чего раньше не происходило вне Docker-сборки.

## Проверка

Полная сборка прогнана локально — `BUILD SUCCESSFUL`, `TrackStudio.war` 37 МБ. Итоговую проверку сделает CI этого PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)