### PR TITLE
README: бейджи статуса сборки

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # TrackStudio Enterprise 6 (Open Source)
 
+[![Build](https://github.com/maximkr/TrackStudio/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/maximkr/TrackStudio/actions/workflows/build.yml?query=branch%3Amain)
+[![Docker Image CI](https://github.com/maximkr/TrackStudio/actions/workflows/docker-image.yml/badge.svg?branch=main)](https://github.com/maximkr/TrackStudio/actions/workflows/docker-image.yml?query=branch%3Amain)
+[![CodeQL](https://github.com/maximkr/TrackStudio/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/maximkr/TrackStudio/actions/workflows/codeql.yml?query=branch%3Amain)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+
 TrackStudio — это классический трекер задач уровня Enterprise с иерархией задач и пользователей, настраиваемыми рабочими процессами, ролями и правами, SLA-правилами и мощным механизмом уведомлений. Поддерживает сотни тысяч задач и десятки тысяч пользователей на одном сервере.
 
 <img alt="image" src="screenshot.png" />


### PR DESCRIPTION
Бейджи не попали в #12: коммит с ними я запушил в 12:43, а PR был смержен в 12:41 — на две минуты раньше, так что коммит остался в уже закрытой ветке. Переношу отдельно, поверх текущего `main`.

Четыре плашки под заголовком:

- **Build** — новый Gradle-workflow из #12
- **Docker Image CI**
- **CodeQL** — workflow был отключён по `disabled_inactivity`, я включил его обратно
- **License** — Apache-2.0

Каждая кликается на историю прогонов своего workflow на ветке `main`.

Проверено, что все три бейджа сейчас отдаются и показывают `passing`.

## Оговорка про CodeQL

Бейдж CodeQL показывал `passing` и в тот период, когда сам workflow был отключён и не запускался с 23 ноября 2025 — он отображает последний прогон, а не то, что проверка работает. Сейчас workflow включён, но `schedule`-триггер в нём остался, а именно он приводит к автоотключению после 60 дней без активности репозитория. Через два тихих месяца бейдж снова начнёт показывать зелёное на неработающей проверке.

Если это мешает — уберите `schedule` из `codeql.yml`, оставив `push` и `pull_request`. Тогда анализ будет идти на каждый PR, а автоотключение не сработает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)